### PR TITLE
🐛 #70 ユーザーに合わせた投稿時刻を表示する

### DIFF
--- a/src/components/AiPost/AccordionItem/AccordionItem.tsx
+++ b/src/components/AiPost/AccordionItem/AccordionItem.tsx
@@ -7,6 +7,16 @@ const AccordionItem = ({ post, order }: { post: Post; order: string }) => {
 
   const { authorName } = useFetchUserNameById(post.authorId);
 
+  // ユーザーの場所を取得し、投稿日時をローカルタイムゾーンで表示する
+  const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+  const localDate = new Date(post.createdAt).toLocaleString(locale, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
   const onClickAccordionToggle = (
     event: React.MouseEvent<HTMLInputElement>
   ) => {
@@ -67,7 +77,7 @@ const AccordionItem = ({ post, order }: { post: Post; order: string }) => {
       <div className="bg-blue-50 rounded-md shadow-sm p-3" ref={childElement}>
         <p className="text-sm text-indigo-500 font-semibold">{authorName}</p>
         <p className="mt-1">{post.content}</p>
-        <p className="text-gray-500 mt-1">{post.createdAt}</p>
+        <p className="text-gray-500 mt-1">{localDate}</p>
       </div>
     </details>
   );

--- a/src/components/AiPost/AiPostItem/AiPostItem.tsx
+++ b/src/components/AiPost/AiPostItem/AiPostItem.tsx
@@ -2,9 +2,15 @@ import { AiPost } from "@/interface/post-interface";
 import AccordionItem from "../AccordionItem/AccordionItem";
 
 const AiPostItem = ({ aiPost }: { aiPost: AiPost }) => {
-  if (!aiPost) {
-    return null;
-  }
+  // ユーザーの場所を取得し、投稿日時をローカルタイムゾーンで表示する
+  const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+  const localDate = new Date(aiPost.createdAt).toLocaleString(locale, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 
   return (
     <div className="max-w-md md:max-w-2xl bg-white rounded-xl shadow-md overflow-hidden m-3">
@@ -22,13 +28,13 @@ const AiPostItem = ({ aiPost }: { aiPost: AiPost }) => {
           {aiPost.content}
         </p>
         <div className="flex mt-2 justify-between">
-          <p className="text-gray-500">{aiPost.createdAt}</p>
+          <p className="text-gray-500">{localDate}</p>
         </div>
         <AccordionItem post={aiPost.posts[0]} order={"1"} />
         <AccordionItem post={aiPost.posts[1]} order={"2"} />
       </div>
     </div>
   );
-}
+};
 
 export default AiPostItem;

--- a/src/components/AiPost/AiPostList/AiPostList.tsx
+++ b/src/components/AiPost/AiPostList/AiPostList.tsx
@@ -3,7 +3,7 @@ import { AiPost } from "../../../interface/post-interface";
 import AiPostItem from "../AiPostItem/AiPostItem";
 import { useFetchAiPost } from "@/hooks/ai-post/useFetchAiPost";
 import { Box } from "@mantine/core";
-import CircularProgress from '@mui/material/CircularProgress';
+import CircularProgress from "@mui/material/CircularProgress";
 
 const AiPostList = ({
   aiPostData,

--- a/src/components/Post/PostItem/PostItem.tsx
+++ b/src/components/Post/PostItem/PostItem.tsx
@@ -24,9 +24,15 @@ const PostItem = ({
     }
   }, [authorName, post.authorId]);
 
-  if (!post) {
-    return null;
-  }
+  // ユーザーの場所を取得し、投稿日時をローカルタイムゾーンで表示する
+  const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+  const localDate = new Date(post.createdAt).toLocaleString(locale, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 
   return (
     <div className="max-w-md md:max-w-2xl bg-white rounded-xl shadow-md overflow-hidden m-3">
@@ -44,7 +50,7 @@ const PostItem = ({
           {post.content}
         </p>
         <div className="flex mt-2 justify-between">
-          <p className="text-gray-500">{post.createdAt}</p>
+          <p className="text-gray-500">{localDate}</p>
           {isOwnPost && (
             <DeletePost postId={post.id} setPostList={setPostList} />
           )}

--- a/src/components/Post/PostList/PostList.tsx
+++ b/src/components/Post/PostList/PostList.tsx
@@ -3,7 +3,7 @@ import PostItem from "../PostItem/PostItem";
 import { useEffect, useState } from "react";
 import { Post } from "@/interface/post-interface";
 import { Box } from "@mantine/core";
-import CircularProgress from '@mui/material/CircularProgress';
+import CircularProgress from "@mui/material/CircularProgress";
 
 const PostList: React.FC = () => {
   const { data, error, isLoading } = useFetchPost();
@@ -27,6 +27,7 @@ const PostList: React.FC = () => {
   if (!postList || postList.length === 0) {
     return <div className="sm:ml-24 mt-20">No post data</div>;
   }
+
   return (
     <div className="my-16 sm:ml-4">
       {postList.map((post) => (


### PR DESCRIPTION
正しい表記で日付を表示するように変更した
ブラウザからユーザーのlocaleを取得し、ユーザーのタイムゾーンに合わせた時刻を表示するようにした

close #70 